### PR TITLE
rename plist file for AppContainer settings

### DIFF
--- a/Sources/AppContainer/Constants.swift
+++ b/Sources/AppContainer/Constants.swift
@@ -11,7 +11,7 @@ import Foundation
 enum Constants {
     static let containerFolderName = ".__app_container__"
 
-    static let appContainerSettingsPlistName = "settings.plist"
+    static let appContainerSettingsPlistName = "com.p-x9.AppContainer.settings.plist"
 
     static let containerInfoPlistName = "container.plist"
 


### PR DESCRIPTION
Renamed settings file from `settings.plist` to `com.p-x9.AppContainer.settings.plist`.

closes #38 

> **Warning**
> Information on the currently active container will be lost.
> This change will not cause any loss of information for containers other than the currently active container.

If you want to carry over information created in previous versions, you will need to rename the file as follows.

```swift
let fileManager = FileManager.default

let home = NSHomeDirectory()
// If you are using it for App Group, change as follows
// let home = fileManager.containerURL(forSecurityApplicationGroupIdentifier: "YOUR APP GROUP IDENTIFIER")!.absoluteString

let libraryPath = home + "/Library"

let oldPath = libraryPath + "/settings.plist"
let newPath = libraryPath + "/com.p-x9.AppContainer.settings.plist"

guard fileManager.fileExists(atPath: oldPath) else { return }
try? fileManager.moveItem(atPath: oldPath, toPath: newPath)
```